### PR TITLE
build: update sentry to version 0.29.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ version = "0.1.0"
 actix-rt = "2.7"
 actix-web = "4"
 crossbeam-channel = "0.5"
-sentry-types = "0.29"
+sentry-types = "0.29.1"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1"


### PR DESCRIPTION
I'm not sure if you wanna keep `0.29` or if you're ok with updating the minor? https://github.com/getsentry/sentry-rust/releases